### PR TITLE
Fix bool dump

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,5 +3,5 @@
 clever_base_env:
   CACHE_DEPENDENCIES: "true"
   CC_RUN_COMMAND:     "~/.local/bin/{{ clever_entry_point }}"
-  ENABLE_METRICS:     "{{ clever_metrics }}"
+  ENABLE_METRICS:     "{{ clever_metrics | lower }}"
   PORT:               "8080"


### PR DESCRIPTION
Default dump of a boolean in Jinja uses the python notation, resulting in this:

```yaml
---
some_var: "True"
```

The value is expected to be `"true"`.

I'm not happy with the fix, @gaetanfl if you know a better way to dump boolean to a given syntax, I'll be happy to patch it.