### PR TITLE
domain: allow the domain to be specified via clever_domain variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Variables for the application
 - `clever_addons`: a list of dict describing addons enabled for the application from which we would use information during deploy, optional.<br/>
   Example: `{ name: pg, env_prefix: POSTGRESQL_ADDON }`
 - `clever_app_tasks_file`: tasks file to be executed after environment and addons variables where gathered. Specific to an app, should be use to run migrations. Optional.
-- `domain`: the domain from which the application should be reachable, optional
+- `clever_domain`: the domain from which the application should be reachable, optional.
+- _Obsolete_: `domain`: Same as above but was replaced by `clever_domain` since v1.4 of this role.
 - `syslog_server`: UDP Syslog server to be used as UDPSyslog drain for the application, optional. Example: `udp://198.51.100.51:12345`.
 - `clever_metrics`: a boolean to enable or disable metrics support. Optional, default to `false`.
 

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -6,10 +6,10 @@
     CONFIGURATION_FILE: "{{ clever_login_file }}"
 
 - name: Configure Domain
-  when: domain is defined
+  when: domain is defined or clever_domain is defined
   command: clever-set-domain.sh
   environment:
-    DOMAIN: "{{ domain }}"
+    DOMAIN: "{{ clever_domain | default(domain) }}"
     CONFIGURATION_FILE: "{{ clever_login_file }}"
 
 - name: Push Environment


### PR DESCRIPTION
Every other variables are prefixed with `clever_` which makes the definition of variables clearer from a "app" configuration point of view.

_The modifications in this PR is **backwards** compatible with exiting `domain` variables_

WDYT?