### PR TITLE
vars: add a clever_syslog_server variable replacing syslog_server

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Variables for the application
 - `clever_app_tasks_file`: tasks file to be executed after environment and addons variables where gathered. Specific to an app, should be use to run migrations. Optional.
 - `clever_domain`: the domain from which the application should be reachable, optional.
 - _Obsolete_: `domain`: Same as above but was replaced by `clever_domain` since v1.4 of this role.
-- `syslog_server`: UDP Syslog server to be used as UDPSyslog drain for the application, optional. Example: `udp://198.51.100.51:12345`.
+- `clever_syslog_server`: UDP Syslog server to be used as UDPSyslog drain for the application, optional. Example: `udp://198.51.100.51:12345`.
+- _Obsolete_: `syslog_server`: Same as above but was replaced by `clever_syslog_server` since v1.5 of this role.
 - `clever_metrics`: a boolean to enable or disable metrics support. Optional, default to `false`.
 
 Variables specific to deployment, default should be fine:

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -1,8 +1,8 @@
 - name: Configure Drain
-  when: syslog_server is defined
+  when: syslog_server is defined or clever_syslog_server is defined
   command: clever-set-drain.sh
   environment:
-    SYSLOG_UDP_SERVER: "{{ syslog_server }}"
+    SYSLOG_UDP_SERVER: "{{ clever_syslog_server | default(syslog_server) }}"
     CONFIGURATION_FILE: "{{ clever_login_file }}"
 
 - name: Configure Domain


### PR DESCRIPTION
All variables "namespaced" with the role name is helpful to read "client" configurations