### PR TITLE
fix: clever_app_root is provided & exec is outside of "parent dir"

### DIFF
--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -26,6 +26,8 @@
 
 - name: Push to Clever-Cloud to trigger deployment
   command: "git push --force git+ssh://git@push-par-clevercloud-customers.services.clever-cloud.com/{{ clever_app }}.git HEAD:refs/heads/master"
+  args:
+    chdir: "{{ clever_app_root }}"
   register: clever_git_push
   ignore_errors: true
   tags:
@@ -33,6 +35,8 @@
 
 - name: First time push to Clever-Cloud needs a full git clone
   command: "git fetch --unshallow"
+  args:
+    chdir: "{{ clever_app_root }}"
   when:
     - clever_git_push is failed
     - clever_git_push.stderr is search("shallow update not allowed")
@@ -41,6 +45,8 @@
 
 - name: Push to Clever-Cloud to trigger deployment
   command: "git push --force git+ssh://git@push-par-clevercloud-customers.services.clever-cloud.com/{{ clever_app }}.git HEAD:refs/heads/master"
+  args:
+    chdir: "{{ clever_app_root }}"
   when: clever_git_push is failed
   tags:
     - skip_ansible_lint


### PR DESCRIPTION
Imagine such a usecase: - project is in `/project` - executing Ansible in `/ansible` with `clever_app_root: /project` will fail deploying with the git push with the following error: ``` Not a git repository (or any of the parent directories): .git" ```

This PR fixes this.