### PR TITLE
fix: 😬 really fix the usage of "clever_app_root" when waiting deploy

### DIFF
--- a/files/clever-wait-deploy.sh
+++ b/files/clever-wait-deploy.sh
@@ -47,4 +47,10 @@ function check {
   deployed "$commit"
 }
 
-check "$(git rev-parse HEAD)"
+function getHeadRev {
+  local chdir="$1/.git"
+
+  git --git-dir="$chdir" rev-parse HEAD
+}
+
+check "$(getHeadRev "$@")"

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -52,7 +52,7 @@
     - skip_ansible_lint
 
 - name: Watch deployment status
-  command: clever-wait-deploy.sh
+  command: "clever-wait-deploy.sh '{{ clever_app_root }}'"
   async: 900
   poll: 0
   register: long_command


### PR DESCRIPTION
Followup after the fix of #15 it was still missing another case of "git" usage.

This should be the last fix about this variable 🤞.