### PR TITLE
avoid hardcoded bash path in scripts

### DIFF
--- a/files/clever-set-domain.sh
+++ b/files/clever-set-domain.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 function checkDomain {
   clever domain | grep "${DOMAIN}"

--- a/files/clever-set-drain.sh
+++ b/files/clever-set-drain.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 function checkDrain {
   clever drain | grep "${SYSLOG_UDP_SERVER}"


### PR DESCRIPTION
This PR fixes the scripts by replacing the hardcoded shebang pointing to `bash`