### PR TITLE
feat(post_deploy): Add a post deploy task to fetch deployed env

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Variables for the application
 - `clever_syslog_server`: UDP Syslog server to be used as UDPSyslog drain for the application, optional. Example: `udp://198.51.100.51:12345`.
 - _Obsolete_: `syslog_server`: Same as above but was replaced by `clever_syslog_server` since v1.5 of this role.
 - `clever_metrics`: a boolean to enable or disable metrics support. Optional, default to `true`.
+- `clever_env_output_file`: as a post deploy task you might need to retrieve the full Clever environment configuration (i.e. with addon env variables). If this variable is set to a filename then the env will be retrieved after a successful deploy inside this file. Optional.
 
 Variables specific to deployment, default should be fine:
 - `clever_cli_version`: Version of clever cli tools, default to `0.9.3`.

--- a/tasks/post_deploy.yml
+++ b/tasks/post_deploy.yml
@@ -1,0 +1,9 @@
+---
+- name: Retrieve clever env if needed
+  shell: "clever env > {{ clever_env_output_file }}"
+  args:
+    chdir: "{{ clever_app_root }}"
+    creates: "{{ clever_env_output_file }}"
+  environment:
+    CONFIGURATION_FILE: "{{ clever_login_file }}"
+  when: clever_env_output_file is defined


### PR DESCRIPTION
In some cases you might need to retrieve the ENV which is currently in
use by your clever application recently deployed.

If you specify a `clever_env_output_file` that is exactly what you
will get!