### PR TITLE
fix: statically include sub tasks for 'tags' to work

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,19 @@
 ---
 # tasks file for clever
 - name: Setup environment for clever
-  include_tasks: setup.yml
+  import_tasks: setup.yml
   tags:
     - clever
     - clever-setup
 
 - name: Login to clever
-  include_tasks: login.yml
+  import_tasks: login.yml
   tags:
     - clever
     - clever-login
 
 - name: Manage environment
-  include_tasks: environment.yml
+  import_tasks: environment.yml
   tags:
     - clever
     - clever-env
@@ -21,18 +21,15 @@
 - name: Include specific tasks
   include_tasks: "{{ clever_app_tasks_file }}"
   when: clever_app_tasks_file is defined
-  tags:
-    - clever
-    - clever-specific-role
 
 - name: Deploy app
-  include_tasks: deploy.yml
+  import_tasks: deploy.yml
   tags:
    - clever
    - clever-deploy
 
 - name: Post deploy tasks
-  include_tasks: post_deploy.yml
+  import_tasks: post_deploy.yml
   tags:
    - clever
    - clever-deploy


### PR DESCRIPTION
In ansible the `include_tasks` loads the tasks dynamically. Thus it
does not apply the tag specified at the include level to all sub
tasks.

In order to make sure all included tasks inherit the specified `tags:`
we need to include the tasks files "statically". It is very similar to
cases where we have a `when:` condition that we want to apply to all
included subtasks. cf https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html#applying-when-to-roles-imports-and-includes