### PR TITLE
deploy: check "up-to-date" error to succeeded if last commit is OK

### DIFF
--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -80,7 +80,41 @@
     - clever_deploy is failed
     - clever_deploy.stderr is defined
 
+- shell: clever activity
+  args:
+    chdir: "{{ clever_app_root }}"
+  environment:
+    CONFIGURATION_FILE: "{{ clever_login_file }}"
+  changed_when: false
+  register: clever_activity_result
+
+- debug:
+    var: clever_activity_result.stdout_lines
+
+- shell: git show -q --format=format:%H HEAD
+  args:
+    chdir: "{{ clever_app_root }}"
+  changed_when: false
+  register: current_commit_sha
+
+# ####
+# Expects all configuration to be located in the project's repository.
+# Making a git commit bound to the same *configuration* and *executable* version.
+# ##
+- name: Fail if current commit is not the last deployed one
+  fail:
+    msg: "The clever deployment failed! Please check latest deploy activity logs above."
+  when:
+    - clever_deploy is failed
+    - clever_deploy.stderr is defined
+    - clever_deploy.stderr is search("application is up-to-date")
+    - clever_activity_valid_deploy_keyword in clever_activity_result.stdout_lines[-1]
+    - current_commit_sha.stdout_lines[-1] in clever_activity_result.stdout_lines[-1]
+
 - name: Fail on deployment errors
   fail:
     msg: "The clever deployment failed! Please check logs above."
-  when: clever_deploy is failed
+  when:
+    - clever_deploy is failed
+    - clever_deploy.stderr is defined
+    - clever_deploy.stderr is not search("application is up-to-date")

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,3 +7,5 @@ clever_base_env:
   CC_RUN_COMMAND:     "~/.local/bin/{{ clever_haskell_entry_point }}"
   ENABLE_METRICS:     "{{ clever_metrics | lower }}"
   PORT:               "8080"
+
+clever_activity_valid_deploy_keyword: " OK "


### PR DESCRIPTION
If deployment fails with an error that contains `application is up-to-date` we check the `clever activity` results to check that the latest entry is an ` OK ` entry and contains the current git commit SHA.

In that case we make the deployment succeeded. In all other error cases, the deployment will fail.