### PR TITLE
login: force the `.clever.json` file to be created

### DIFF
--- a/tasks/login.yml
+++ b/tasks/login.yml
@@ -13,6 +13,6 @@
   command: clever link {{ clever_app }}
   args:
     chdir: "{{ clever_app_root }}"
-    creates: "{{ clever_app_root }}/.clever.json"
+  changed_when: true
   environment:
     CONFIGURATION_FILE: "{{ clever_login_file }}"


### PR DESCRIPTION
In case a project already has a `.clever.json` file (for debugging
purpose to communicate with dev environment for instance) this step
was never done because of the `creates:`.

Removing it forces the role to always create a new clever.json file.