### PR TITLE
fix(lint): ansible lint 4.1.0 compatibiliy

### DIFF
--- a/tasks/addon.yml
+++ b/tasks/addon.yml
@@ -1,5 +1,6 @@
 - name: Gather addon information for {{ addon.name }}
   shell: >
+    set -o pipefail &&
     clever env | grep {{ addon.env_prefix }}
     | sed -e 's/{{ addon.env_prefix }}_//' -e 's/=/: \"/' -e 's/$/\"/'
     > {{ clever_app_confdir }}/{{ addon.name }}_env.yml


### PR DESCRIPTION
ansible-lint 4.1.0 introduced a new rule to detect failing shell command involving a pipe.
This PR fixes the linting error raised