### PR TITLE
update metrics and entrypoint default definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Ansible role for clever cloud deployment
 Clever deploy
 =========
 
-This roles deploy an haskell app on clever cloud (https://www.clever-cloud.com).
+This role deploys applications on clever cloud (https://www.clever-cloud.com).
+It handles the publication over git, as well as domain names, environment variables and log drains configuration.
 
 Requirements
 ------------
@@ -31,7 +32,8 @@ Variables for the application
 - _Obsolete_: `domain`: Same as above but was replaced by `clever_domain` since v1.4 of this role.
 - `clever_syslog_server`: UDP Syslog server to be used as UDPSyslog drain for the application, optional. Example: `udp://198.51.100.51:12345`.
 - _Obsolete_: `syslog_server`: Same as above but was replaced by `clever_syslog_server` since v1.5 of this role.
-- `clever_metrics`: a boolean to enable or disable metrics support. Optional, default to `true`.
+- _Obsolete_: `clever_metrics`: metrics used to be disabled by default. Now they are enabled by default and can be explicitly disabled with `clever_disable_metrics`.
+- `clever_disable_metrics`: a boolean to disable metrics support. Optional, default to `false`.
 - `clever_env_output_file`: as a post deploy task you might need to retrieve the full Clever environment configuration (i.e. with addon env variables). If this variable is set to a filename then the env will be retrieved after a successful deploy inside this file. Optional.
 
 Variables specific to deployment, default should be fine:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ clever_login_file: "{{ clever_app_confdir }}/login"
 clever_haskell_entry_point: "{{ clever_entry_point | default('') }}"
 clever_env: {}
 
-clever_metrics: true
+clever_disable_metrics: false
 
 clever_addons: []
 # example

--- a/dhall/Config.dhall
+++ b/dhall/Config.dhall
@@ -17,7 +17,7 @@ in    λ(Environment : Type)
           Optional Text
       , clever_haskell_entry_point :
           Optional Text
-      , clever_metrics :
+      , clever_disable_metrics :
           Bool
       , clever_addons :
           List Addon

--- a/dhall/mkConfig.dhall
+++ b/dhall/mkConfig.dhall
@@ -23,8 +23,8 @@ in    λ(vault : Vault)
             None Text
         , clever_haskell_entry_point =
             None Text
-        , clever_metrics =
-            True
+        , clever_disable_metrics =
+            False
         , clever_addons =
             [] : List Addon
         , clever_env =

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,7 +5,7 @@ clever_base_env:
   # Haskell only
   # https://www.clever-cloud.com/doc/get-help/reference-environment-variables/#haskell
   CC_RUN_COMMAND:     "~/.local/bin/{{ clever_haskell_entry_point }}"
-  ENABLE_METRICS:     "{{ clever_metrics | lower }}"
+  CC_DISABLE_METRICS: "{{ clever_metrics is defined | ternary(not clever_metrics, clever_disable_metrics) | lower }}"
   PORT:               "8080"
 
 clever_activity_valid_deploy_keyword: " OK "


### PR DESCRIPTION
# Context

Clever cloud metrics are now enabled by default, and can now be disabled with `DISABLE_METRICS`. I've updated the definition to reflect this change.