### PR TITLE
Fix `CC_DISABLE_METRICS` computation

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,7 +5,7 @@ clever_base_env:
   # Haskell only
   # https://www.clever-cloud.com/doc/get-help/reference-environment-variables/#haskell
   CC_RUN_COMMAND:     "~/.local/bin/{{ clever_haskell_entry_point }}"
-  CC_DISABLE_METRICS: "{{ clever_metrics is defined | ternary(not clever_metrics, clever_disable_metrics) | lower }}"
+  CC_DISABLE_METRICS: "{{ clever_disable_metrics | lower }}"
   PORT:               "8080"
 
 clever_activity_valid_deploy_keyword: " OK "


### PR DESCRIPTION
The reference to `clever_metrics` made the env generation task fail. This setting is not actually used anyway and is currently broken, so we can forego backwards compat.