### PR TITLE
Remove `sshKey` from the vault type

### DIFF
--- a/dhall/Vault.dhall
+++ b/dhall/Vault.dhall
@@ -1,1 +1,1 @@
-{ token : Text, secret : Text, sshKey : Text }
+{ token : Text, secret : Text }


### PR DESCRIPTION
It's not actually used by the role, but by code that uses this role.

Of course this will require us to update ci-commons to comply