### PR TITLE
deploy: add a timeout in the polling waiting script

### DIFF
--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -88,10 +88,21 @@
     jid: "{{ long_command.ansible_job_id }}"
   register: job_result
   until: job_result.finished
+  ignore_errors: true
   delay: 30
   retries: 80 # 40 minutes (80 * 30 secs delay)
 
-# Output of waiting script stdout
-- name: Output waiting script logs
+- name: Waiting script logs (stdout)
   debug:
     var: job_result.stdout_lines
+  when: job_result.stdout_lines is defined
+
+- name: Waiting script logs (stderr)
+  debug:
+    var: job_result.stderr_lines
+  when: job_result.stderr_lines is defined
+
+- name: Fail in case of timeout or failure
+  fail:
+    msg: "Deployment failed. Please check logs above."
+  when: not job_result.finished or not job_result.rc == 0


### PR DESCRIPTION
This PR adds:

- a timeout in the bash script
- an output of both stdout and stderr of the bash script even if script failed

----

#