### PR TITLE
fix: addon environment variables fetch for clever >= 1.5.0

### DIFF
--- a/tasks/addon.yml
+++ b/tasks/addon.yml
@@ -1,4 +1,4 @@
-- name: Gather addon information for {{ addon.name }}
+- name: Gather addon information for {{ addon.name }} (clever --version < 1.5.0)
   shell: >
     set -o pipefail &&
     clever env | grep {{ addon.env_prefix }}
@@ -10,6 +10,21 @@
   environment:
     CONFIGURATION_FILE: "{{ clever_login_file }}"
   changed_when: False
+  when: clever_returned_version.stdout is version('1.5.0', '<')
+
+- name: Gather addon information for {{ addon.name }} (clever --version >= 1.5.0)
+  shell: >
+    set -o pipefail &&
+    clever env | grep {{ addon.env_prefix }}
+    | sed -e 's/{{ addon.env_prefix }}_//' -e 's/=/: /'
+    > {{ clever_app_confdir }}/{{ addon.name }}_env.yml
+  args:
+    chdir: "{{ clever_app_root }}"
+    executable: "bash"
+  environment:
+    CONFIGURATION_FILE: "{{ clever_login_file }}"
+  changed_when: False
+  when: clever_returned_version.stdout is version('1.5.0', '>=')
 
 - name: Include addon var for {{ addon.name }}
   include_vars:


### PR DESCRIPTION
It seems the output of `clever env` has changed and now env values are
surrounded by quotes with the latest 1.6.2 clever tools version.

We used to add quotes ourselves because they were missing in the
output. So this commit is adapting its parsing depending of the clever
tools' version.