### PR TITLE
Quote env vars to support multiline values

### DIFF
--- a/templates/env.j2
+++ b/templates/env.j2
@@ -1,3 +1,3 @@
 {% for key, value in (clever_base_env | combine(clever_env)).items() %}
-{{ key }}={{ value }}
+{{ key }}="{{ value | tojson }}"
 {% endfor %}


### PR DESCRIPTION
clever-tools now supports multiline env vars. It did so by supporting
quotes in the formats it reads from.
This commit quotes the exported values using the `tojson` filter.

Of course, a better solution would be for clever env to directly read
json value, but it's not there yet (https://github.com/CleverCloud/clever-tools/pull/326)