### PR TITLE
ci: fix nix version and nix channel version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 ---
-language: nix
-
 sudo: false
+language: nix
+nix: 2.2.1
+env:
+  - NIX_PATH=nixpkgs=channel:nixos-19.09
 
 install:
-  - nix-env -i python2.7-ansible python2.7-ansible-lint ShellCheck-0.7.0
+  - nix-env -iA pkgs.python37Packages.ansible-lint pkgs.python37Packages.ansible pkgs.shellcheck -f '<nixpkgs>'
   - nix-env -if ./dhall-1.26.1.nix
 
   # Check ansible version


### PR DESCRIPTION
In order to avoid having bad surprises with automatic updates let's
fix the nix channel version. For now the default travis behavior is to
use `nixpkgs-unstable` (see
https://docs.travis-ci.com/user/languages/nix#overview).