### PR TITLE
fix `clever_base_env`  by removing a variable if not necessary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,12 @@ script:
   - ansible-lint .
   - shellcheck **/*.sh
   - scripts/dhall_check.sh
+  # Run integration test
+  - mkdir -p ~/.local/bin
+  - cp tests/fake.sh ~/.local/bin/clever
+  - cp tests/fake.sh ~/.local/bin/git
+  - ansible-playbook tests/test.yml -i tests/inventory
 
 notifications:
   slack: fretlink:pTIylIN7zkwRFuL3aHERmsbB
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,12 @@
 ---
 # defaults file for clever
-clever_cli_version: 1.4.2
+clever_cli_version: 1.6.3
 clever_user_path: .local/bin
 clever_app_root: "{{ app_root | default(playbook_dir + '/..') }}"
 clever_app_confdir: "{{ clever_app_root }}/.clever_cloud"
 clever_login_file: "{{ clever_app_confdir }}/login"
 
-clever_haskell_entry_point: "{{ clever_entry_point | default('') }}"
+clever_haskell_entry_point: "{{ clever_entry_point | default(None) }}"
 clever_env: {}
 
 clever_disable_metrics: false

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -1,3 +1,9 @@
 {% for key, value in (clever_base_env | combine(clever_env)).items() %}
-{{ key }}="{{ value | tojson }}"
+{{ key }}="{{ value | to_json }}"
 {% endfor %}
+
+{%- if clever_haskell_entry_point %}
+{# Haskell only #}
+{# https://www.clever-cloud.com/doc/get-help/reference-environment-variables/#haskell #}
+CC_RUN_COMMAND="{{'~/.local/bin/' + clever_haskell_entry_point | to_json }}"
+{% endif %}

--- a/tests/fake.sh
+++ b/tests/fake.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+binary="${0/*\/}"
+fakeCommit="aaa000aaa000aaa000aaa000aaa000aaa000aaa0"
+
+if [ "${binary}" = "clever" ] && [ "${1}" = "--version" ]; then
+    echo "1.6.3"
+elif [ "${binary}" = "clever" ] && [ "${1}" = "activity" ]; then
+    echo "2020-02-02T20:20:02+02:00  OK         DEPLOY     ${fakeCommit}  Git"
+elif [ "${binary}" = "git" ]; then
+    echo "${fakeCommit}"
+else
+    echo "${binary} called with arguments: ${*}"
+fi

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,2 +1,2 @@
-localhost
+localhost ansible_connection=local
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,8 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - clever
+    - role: clever
+      vars:
+        clever_token: 123abc
+        clever_secret: cba321
+        clever_app: app_00000000-0000-0000-0000-000000000000

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,9 +2,6 @@
 # vars file for clever
 clever_base_env:
   CACHE_DEPENDENCIES: "true"
-  # Haskell only
-  # https://www.clever-cloud.com/doc/get-help/reference-environment-variables/#haskell
-  CC_RUN_COMMAND:     "~/.local/bin/{{ clever_haskell_entry_point }}"
   CC_DISABLE_METRICS: "{{ clever_disable_metrics | lower }}"
   PORT:               "8080"
 


### PR DESCRIPTION
The `CC_RUN_COMMAND` variable was defined in case we use haskell
binary as entrypoints. However if the `clever_haskell_entry_point`
variable is not defined we shouldn't define the `CC_RUN_COMMAND` env variable as it will create an error at deployment time.