### PR TITLE
fix: there was a bug in the generate env file

### DIFF
--- a/templates/env.j2
+++ b/templates/env.j2
@@ -1,9 +1,9 @@
 {% for key, value in (clever_base_env | combine(clever_env)).items() %}
-{{ key }}="{{ value | to_json }}"
+{{ key }}={{ value | to_json }}
 {% endfor %}
 
 {%- if clever_haskell_entry_point %}
 {# Haskell only #}
 {# https://www.clever-cloud.com/doc/get-help/reference-environment-variables/#haskell #}
-CC_RUN_COMMAND="{{'~/.local/bin/' + clever_haskell_entry_point | to_json }}"
+CC_RUN_COMMAND={{'~/.local/bin/' + clever_haskell_entry_point | to_json }}
 {% endif %}


### PR DESCRIPTION
Bug Introduced by #57 because the `to_json` filter quotes the given
value if it's a string, so the PR was "double quoting" each values.