### PR TITLE
environment: re-order projet env & addon env

### DIFF
--- a/tasks/environment.yml
+++ b/tasks/environment.yml
@@ -1,11 +1,11 @@
-- name: Create environment file
-  template:
-    src: env.j2
-    dest: "{{ clever_app_confdir }}/env"
-  no_log: true
-
 - name: Create addons variable file
   include_tasks: addon.yml
   vars:
     addon: "{{ item }}"
   with_items: "{{ clever_addons }}"
+
+- name: Create environment file
+  template:
+    src: env.j2
+    dest: "{{ clever_app_confdir }}/env"
+  no_log: true


### PR DESCRIPTION
By fetching addon environment variables before setting the current
project env variables we allow the project variables to _read_ its
addons' variables.

This can be helpful when you don't control the name of the environment
variables your project is using (and thus want to do a mapping between
the addons variable name exposed by clever to a variable name your
project can understand).