### PR TITLE
deploy: try to restart the app when the CLI asks to do it

### DIFF
--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -85,6 +85,13 @@
     - job_result.stderr is defined
     - job_result.stderr is search("Failed to read git object")
 
+- name: Restart app on clever-cloud when error asks to restart
+  include_tasks: restart.yml
+  when:
+    - not job_result.finished or not job_result.rc == 0
+    - job_result.stderr is defined
+    - job_result.stderr is search("clever restart")
+
 - name: Deploy logs (stdout)
   debug:
     var: job_result.stdout_lines

--- a/tasks/restart.yml
+++ b/tasks/restart.yml
@@ -1,6 +1,13 @@
 ---
+- name: Get current HEAD commit revision
+  command: "git rev-parse HEAD" # noqa 303
+  register: git_head_revision
+  args:
+    chdir: "{{ clever_app_root }}"
+  changed_when: false
+
 - name: Restart app on Clever-Cloud
-  shell: "clever restart"
+  shell: "clever restart --commit {{ git_head_revision.stdout_lines | first }}"
   args:
     chdir: "{{ clever_app_root }}"
   environment:

--- a/tests/fake.sh
+++ b/tests/fake.sh
@@ -3,6 +3,9 @@
 binary="${0/*\/}"
 localCommit="${PRETEND_LOCAL_COMMIT:-aaa000aaa000aaa000aaa000aaa000aaa000aaa0}"
 remoteCommit="${PRETEND_REMOTE_COMMIT:-bbb000bbb000bbb000bbb000bbb000bbb000bbb0}"
+uptodateDeployment="${DEPLOY_UP_TO_DATE_APP:-}"
+
+echo "${1}" >> "${binary}-commands"
 
 if [ "${binary}" = "clever" ] && [ "${1}" = "--version" ]; then
     echo "2.6.1"
@@ -10,10 +13,17 @@ elif [ "${binary}" = "clever" ] && [ "${1}" = "activity" ]; then
     echo "2020-02-02T20:20:02+02:00  OK         DEPLOY     ${remoteCommit}  Git"
 elif [ "${binary}" = "clever" ] && [ "${1}" = "status" ]; then
     echo "test-app: running (1*pico,  Commit: ${remoteCommit})"
+elif [ "${binary}" = "clever" ] && [ "${1}" = "deploy" ]; then
+    if [ -z "${uptodateDeployment}" ]; then
+        echo "Clever deploy done."
+    else
+        # Mimic the current behavior until https://github.com/CleverCloud/clever-tools/issues/422 is solved
+        >&2 echo "The clever-cloud application is up-to-date. Try this command to restart the application:"
+        >&2 echo "        clever restart"
+        exit 1
+    fi
 elif [ "${binary}" = "git" ]; then
     echo "${localCommit}"
 else
     echo "${binary} called with arguments: ${*}"
 fi
-
-echo "${1}" >> "${binary}-commands"

--- a/tests/test-all.yml
+++ b/tests/test-all.yml
@@ -3,6 +3,7 @@
 - import_playbook: ./test-configure-app.yml
 - import_playbook: ./test-haskell-app.yml
 - import_playbook: ./test-noop-deploy.yml
+- import_playbook: ./test-restart-deploy.yml
 - import_playbook: ./test-scalability.yml
 - import_playbook: ./test-service-deps.yml
 - import_playbook: ./test-restart-app.yml

--- a/tests/test-restart-deploy.yml
+++ b/tests/test-restart-deploy.yml
@@ -1,0 +1,37 @@
+---
+- name: Launch a restart when commit is already up-to-date on clever
+  hosts: localhost
+  remote_user: root
+  pre_tasks:
+    - file:
+        state: absent
+        path: ../clever-commands
+  roles:
+    - role: clever
+      vars:
+        clever_token: 123abc
+        clever_secret: cba321
+        clever_app: app_00000000-0000-0000-0000-000000000000
+      environment:
+        DEPLOY_UP_TO_DATE_APP: true
+  post_tasks:
+    - name: Check stubbed commands
+      shell: "{{ item.cmd }}"
+      ignore_errors: true
+      with_list:
+        - cmd: "grep deploy ../clever-commands"
+          display: "Expected 'clever deploy' command to be called"
+        - cmd: "grep restart ../clever-commands"
+          display: "Expected 'clever restart' command to be called"
+      vars:
+        display: "{{ item.display }}"
+      register: tests_results
+    - name: show results
+      debug:
+        msg:
+          - "failed_results: {{ failed_results }}"
+          - "success_results: {{ success_results }}"
+      failed_when: tests_results is failed
+      vars:
+        failed_results: "{{ tests_results.results | selectattr('failed') | map(attribute='item.display') | list }}"
+        success_results: "{{ tests_results.results | rejectattr('failed') | map(attribute='item.display') | list }}"


### PR DESCRIPTION
In some cases (rollback or deployment errored on clever side),
clever-tools will fail when calling `clever deploy` because it thinks
the currently being deployed commit is already deployed. However in
some cases the git pushed commit is not the currently running commit.

Leading to a failure in our deployment process. The proposed solution
from the clever tools error is to launch `clever restart`.

Until we wait for
https://github.com/CleverCloud/clever-tools/issues/422 to be fixed,
let's do what the error message say: try to restart in case of a
deployment failure.